### PR TITLE
Fix NaN bugs

### DIFF
--- a/sankee/core.py
+++ b/sankee/core.py
@@ -194,7 +194,7 @@ def _extract_values_from_images_at_points(image_list, sample_points, band, scale
     """
 
     def extract_values_from_images_at_one_point(point):
-        point_location = point.geometry()
+        point_location = ee.Element.geometry(point)
 
         def extract_value_from_image_at_one_point(img, feature):
             cover = ee.Image(img).reduceRegion(ee.Reducer.first(), point_location, scale).get(band)

--- a/sankee/core.py
+++ b/sankee/core.py
@@ -171,7 +171,20 @@ def _collect_sample_data(image_list, region, dataset, label_list, n=100, scale=N
         else:
             raise e
 
+    _check_for_missing_samples(data, label_list)
+
     return data[label_list]
+
+
+def _check_for_missing_samples(data, label_list):
+    """
+    Check that the sampled data has a column for each label in the label list. If not, it may be that sampling occured
+    outside of the image bounds.
+    """
+    missing_labels = [label for label in label_list if label not in data.columns]
+    if missing_labels:
+        raise Exception(f"No valid samples were collected in these images: {missing_labels}. Check that the sampling"\
+        " region overlaps the image bounds.")
 
 
 def _extract_values_from_images_at_points(image_list, sample_points, band, scale):

--- a/sankee/core.py
+++ b/sankee/core.py
@@ -69,10 +69,9 @@ def sankify(
 
     labeled_images = _label_images(image_list, label_list)
     sample_data = _collect_sample_data(labeled_images, region, dataset, label_list, n, scale, seed)
-
-    dataset.check_data_is_compatible(sample_data)
-
     cleaned_data = _clean_data(sample_data, exclude, max_classes, dropna=dropna)
+
+    dataset.check_data_is_compatible(cleaned_data)
 
     return _generate_sankey_plot(cleaned_data, dataset, title)
 


### PR DESCRIPTION
- Fix/implement #8: Check that each image has been sampled before returning sampling data and raise a more helpful error if not. 
- Fix #9: Check for dataset compatibility after cleaning to ensure that nan values aren't marked as incompatible with the dataset. 
- Fix a deprecation warning from earthengine-api