### PR TITLE
Explicit cast to int to avoid KeyErrors #22

### DIFF
--- a/sankee/sampling.py
+++ b/sankee/sampling.py
@@ -43,7 +43,7 @@ def collect_sankey_data(
         else:
             raise e
 
-    data = pd.DataFrame.from_dict(features).dropna()
+    data = pd.DataFrame.from_dict(features).dropna().astype(int)
 
     for image in image_labels:
         if image not in data.columns:


### PR DESCRIPTION
Fix #22 

If null values are sampled in one time step (e.g. nodata classes or masked areas), the resulting dataframe column will be cast to float before the nans can be dropped. When `value_counts` is run, you'll get a dataframe with a float index. Slicing that dataframe with an int index will throw a KeyError. 

Explicitly casting to int after dropping nans avoids the float index problem and solves the issue.