### PR TITLE
Store `samples` attribute in `SankeyPlot` (#25)

### DIFF
--- a/sankee/plotting.py
+++ b/sankee/plotting.py
@@ -7,8 +7,7 @@ import ipywidgets as widgets
 import pandas as pd
 import plotly.graph_objects as go
 
-from sankee import utils
-from sankee.sampling import collect_sankey_data
+from sankee import sampling, utils
 
 SankeyParameters = namedtuple(
     "SankeyParameters",
@@ -99,23 +98,23 @@ def sankify(
     if len(set(label_list)) != len(label_list):
         raise ValueError("All labels in the `label_list` must be unique.")
 
-    sample_data = collect_sankey_data(
+    data, samples = sampling.generate_sample_data(
         image_list=image_list,
         image_labels=label_list,
-        region=region,
         band=band,
-        n=n,
         scale=scale,
-        seed=seed,
         include=list(labels.keys()),
         max_classes=max_classes,
+        region=region,
+        n=n,
     )
 
     return SankeyPlot(
-        data=sample_data,
+        data=data,
         labels=labels,
         palette=palette,
         title=title,
+        samples=samples,
     )
 
 
@@ -126,11 +125,13 @@ class SankeyPlot(widgets.DOMWidget):
         labels: Dict[int, str],
         palette: Dict[int, str],
         title: str,
+        samples: ee.FeatureCollection,
     ):
         self.data = data
         self.labels = labels
         self.palette = palette
         self.title = title
+        self.samples = samples
 
         self.hide = []
         self.plot = self.generate_plot()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -19,6 +19,7 @@ def sankey():
         labels=TEST_DATASET.labels,
         palette=TEST_DATASET.palette,
         title="",
+        samples=None,
     )
 
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -6,53 +6,56 @@ import sankee.sampling
 from .data import TEST_DATASET, TEST_IMAGE_LABELS, TEST_IMAGE_LIST, TEST_REGION
 
 
-def test_collect_sankey_data():
+def test_sample_data():
     """Test that the correct number of rows and columns are sampled."""
     n = 10
-
-    data = sankee.sampling.collect_sankey_data(
+    data, samples = sankee.sampling.generate_sample_data(
         image_list=TEST_IMAGE_LIST,
         image_labels=TEST_IMAGE_LABELS,
         region=TEST_REGION,
         band=TEST_DATASET.band,
-        n=n,
+        scale=100,
+        n=10,
     )
 
     assert len(data) == n
     assert data.columns.tolist() == TEST_IMAGE_LABELS
+    assert samples.size().getInfo() == n
 
 
-def test_collect_sankey_data_bad_band():
+def test_sample_data_bad_band():
     """Test that an error is thrown when sampling an invalid band."""
     with pytest.raises(ValueError, match="band `foo` was not found"):
-        sankee.sampling.collect_sankey_data(
+        sankee.sampling.generate_sample_data(
             image_list=TEST_IMAGE_LIST,
             image_labels=TEST_IMAGE_LABELS,
             region=TEST_REGION,
             band="foo",
+            scale=100,
             n=10,
         )
 
 
-def test_collect_sankey_data_bad_region():
+def test_sample_data_bad_region():
     """Test that an error is thrown when sampling occurs outside the dataset."""
     with pytest.raises(ValueError, match="samples were not found"):
-        sankee.sampling.collect_sankey_data(
+        sankee.sampling.generate_sample_data(
             image_list=TEST_IMAGE_LIST,
             image_labels=TEST_IMAGE_LABELS,
             region=ee.Geometry.Point(0, 0).buffer(100),
             band=TEST_DATASET.band,
+            scale=100,
             n=10,
         )
 
 
-def test_collect_sankey_data_point():
-    """Test that an error is thrown when sampling a point."""
-    with pytest.raises(ValueError, match="must be a 2D geometry"):
-        sankee.sampling.collect_sankey_data(
+def test_sample_data_point():
+    """Test that an error is thrown when sampling occurs on an empty FeatureCollection."""
+    with pytest.raises(ValueError, match="pass a 2D `region`"):
+        sankee.sampling.generate_sample_data(
             image_list=TEST_IMAGE_LIST,
             image_labels=TEST_IMAGE_LABELS,
-            region=ee.Geometry.Point(0, 0),
+            region=ee.Geometry.Point([0, 0]),
             band=TEST_DATASET.band,
-            n=10,
+            scale=100,
         )


### PR DESCRIPTION
Close #25.

This refactors the `sampling` module, combining the functions into a single function that returns both the formatted data and the sampled FeatureCollection, which can now be used when initializing a `SankeyPlot`.