### PR TITLE
Fix CCAP projection to allow plotting without specifying `scale` (#29)

### DIFF
--- a/sankee/datasets.py
+++ b/sankee/datasets.py
@@ -211,6 +211,7 @@ class CCAP_Dataset(Dataset):
                 }
             )
             .clip(imgs.geometry())
+            .setDefaultProjection("EPSG:5070")
         )
 
         img = self.set_visualization_properties(img)


### PR DESCRIPTION
Close #29

Projection information is lost when the CCAP images are mosaiced,
which prevents `reduceRegion` from running unless `scale` is
specified. Explicitly setting the default projection fixes that.
EPSG:5070 is a reasonable choice since CCAP is a CONUS dataset.