### PR TITLE
Fix image order bug

### DIFF
--- a/sankee/sampling.py
+++ b/sankee/sampling.py
@@ -57,6 +57,10 @@ def generate_sample_data(
                 " image overlaps the sampling region."
             )
 
+    # EE data gets sorted alpha, so re-sort columns to the image order. Run this after the column
+    # check because this can add columns that were missing.
+    data = data.reindex(image_labels, axis=1)
+    
     if include is not None:
         data = data[data.isin(include).all(axis=1)]
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -8,7 +8,8 @@ TEST_IMAGE_LIST = [
     TEST_DATASET.get_year(1985),
     TEST_DATASET.get_year(2010),
 ]
-TEST_IMAGE_LABELS = ["1985", "2010"]
+# Use labels that don't sort alpha to ensure order stays correct
+TEST_IMAGE_LABELS = ["Start (1985)", "End (2010)"]
 TEST_REGION = ee.Geometry.Point([-122.192688, 46.25917]).buffer(1000)
 
 TEST_DATA = pd.DataFrame(


### PR DESCRIPTION
Earth Engine sorts `FeatureCollection` columns alphabetically, which can lead to figures with incorrect label order. This fix re-sorts the columns after sampling from Earth Engine to ensure the label order matches the requested order. Also modifies the sampling test data to prevent regression.

Close #32