### PR TITLE
Update LCMS datasets to v2022.8 (#43)

### DIFF
--- a/sankee/datasets.py
+++ b/sankee/datasets.py
@@ -231,7 +231,7 @@ class CCAP_Dataset(Dataset):
 
 LCMS_LU = LCMS_Dataset(
     name="LCMS LU - Land Change Monitoring System Land Use",
-    id="USFS/GTAC/LCMS/v2021-7",
+    id="USFS/GTAC/LCMS/v2022-8",
     band="Land_Use",
     labels={
         1: "Agriculture",
@@ -251,14 +251,14 @@ LCMS_LU = LCMS_Dataset(
         6: "#c2b34a",
         7: "#1B1716",
     },
-    years=tuple(range(1985, 2022)),
+    years=tuple(range(1985, 2023)),
     nodata=7,
 )
 
 # https://developers.google.com/earth-engine/datasets/catalog/USFS_GTAC_LCMS_v2020-5
 LCMS_LC = LCMS_Dataset(
     name="LCMS LC - Land Change Monitoring System Land Cover",
-    id="USFS/GTAC/LCMS/v2021-7",
+    id="USFS/GTAC/LCMS/v2022-8",
     band="Land_Cover",
     labels={
         1: "Trees",
@@ -294,7 +294,7 @@ LCMS_LC = LCMS_Dataset(
         14: "#4780f3",
         15: "#1B1716",
     },
-    years=tuple(range(1985, 2022)),
+    years=tuple(range(1985, 2023)),
     nodata=15,
 )
 
@@ -663,7 +663,7 @@ LCMAP = Dataset(
         7: "#FFFFFF",
         8: "#B3B0A3",
     },
-    years=tuple(range(1985, 2021)),
+    years=tuple(range(1985, 2022)),
 )
 
 CORINE = Dataset(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -18,14 +18,14 @@ def test_get_year_nlcd():
 def test_get_year_LCMS_LC():
     dataset = sankee.datasets.LCMS_LC
     img = dataset.get_year(2016)
-    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2021-7/LCMS_CONUS_v2021-7_2016"
+    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2022-8/LCMS_CONUS_v2022-8_2016"
     assert img.bandNames().getInfo() == [dataset.band]
 
 
 def test_get_year_LCMS_LU():
     dataset = sankee.datasets.LCMS_LU
     img = dataset.get_year(2016)
-    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2021-7/LCMS_CONUS_v2021-7_2016"
+    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2022-8/LCMS_CONUS_v2022-8_2016"
     assert img.bandNames().getInfo() == [dataset.band]
 
 
@@ -66,7 +66,7 @@ def test_get_year_LCMAP():
     img = dataset.get_year(2016)
     assert (
         img.get("system:id").getInfo()
-        == "projects/sat-io/open-datasets/LCMAP/LCPRI/LCMAP_CU_2016_V12_LCPRI"
+        == "projects/sat-io/open-datasets/LCMAP/LCPRI/LCMAP_CU_2016_V13_LCPRI"
     )
     assert img.bandNames().getInfo() == [dataset.band]
 
@@ -80,9 +80,9 @@ def test_get_year_CORINE():
     assert img.bandNames().getInfo() == [dataset.band]
 
 
-def test_years():
-    for dataset in sankee.datasets.datasets:
-        assert dataset.years == tuple(dataset.list_years().getInfo())
+@pytest.mark.parametrize("dataset", sankee.datasets.datasets, ids=lambda d: d.name)
+def test_years(dataset):
+    assert dataset.years == tuple(dataset.list_years().getInfo())
 
 
 def test_get_unsupported_year():


### PR DESCRIPTION
The issue in #43 was caused by outdated LCMS datasets. This updates to the new versions. Additionally, the year ranges for LCMS and LCMAP datasets are extended to include newly added years.

Closes #43