### PR TITLE
Subset numeric columns before applying groupby mean

### DIFF
--- a/sankee/plotting.py
+++ b/sankee/plotting.py
@@ -150,13 +150,15 @@ class SankeyPlot(widgets.DOMWidget):
     def get_sorted_classes(self) -> pd.Series:
         """Return all unique class values, sorted by the total number of observations."""
         start_count = (
-            self.df.groupby("source")
+            self.df.loc[:, ["source", "total"]]
+            .groupby("source")
             .mean()
             .reset_index()[["source", "total"]]
             .rename(columns={"source": "class", "total": "count"})
         )
         end_count = (
-            self.df.groupby("target")
+            self.df.loc[:, ["target", "changed"]]
+            .groupby("target")
             .sum()
             .reset_index()[["target", "changed"]]
             .rename(columns={"target": "class", "changed": "count"})


### PR DESCRIPTION
Fixes #42 by subsetting dataframes to numeric columns before applying the groupby mean. Previously we just implictly threw the non-numeric columns away, so this just makes that explicit.