### PR TITLE
Pin `plotly<6` for `go.FigureWidget` compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,8 @@ dependencies = [
     "earthengine-api>=0.1.230",
     "numpy",
     "pandas",
-    "plotly>=5.2.2",
+    "plotly>=5.2.2,<6.0",
     "ipywidgets",
-    "anywidget",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,15 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "earthengine-api>=0.1.230",
     "numpy",
     "pandas",
     "plotly>=5.2.2",
-    "ipywidgets"
+    "ipywidgets",
+    "anywidget",
 ]
 
 [project.urls]


### PR DESCRIPTION
With Plotly 6.0.0, `go.FigureWidget` is now implemented with `anywidget`. We use `go.FigureWidget` to combine the Sankey plot with button widgets in a single figure. Our options now are 1) depend on `anywidget` or 2) pin Plotly to an older release.

The long-term plan will be 1) depend on `anywidget`, but for now this pins Plotly prior to this switch to avoid an issue that prevents the Sankey plot resizing within the `FigureWidget` in the `anywidget` version. Once https://github.com/plotly/plotly.py/issues/5208 is resolved, I'll probably undo the pin in favor of adding `anywidget`.