### PR TITLE
Dataset updates

### DIFF
--- a/sankee/datasets.py
+++ b/sankee/datasets.py
@@ -358,7 +358,7 @@ NLCD2016 = NLCD
 
 MODIS_LC_TYPE1 = Dataset(
     name="MCD12Q1 - MODIS Global Land Cover Type 1",
-    id="MODIS/006/MCD12Q1",
+    id="MODIS/061/MCD12Q1",
     band="LC_Type1",
     labels={
         1: "Evergreen conifer forest",
@@ -398,13 +398,13 @@ MODIS_LC_TYPE1 = Dataset(
         16: "#f9ffa4",
         17: "#1c0dff",
     },
-    years=tuple(range(2001, 2021)),
+    years=tuple(range(2001, 2024)),
 )
 
 # https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MCD12Q1
 MODIS_LC_TYPE2 = Dataset(
     name="MCD12Q1 - MODIS Global Land Cover Type 2",
-    id="MODIS/006/MCD12Q1",
+    id="MODIS/061/MCD12Q1",
     band="LC_Type2",
     labels={
         0: "Water",
@@ -442,13 +442,13 @@ MODIS_LC_TYPE2 = Dataset(
         14: "#ff6d4c",
         15: "#f9ffa4",
     },
-    years=tuple(range(2001, 2021)),
+    years=tuple(range(2001, 2024)),
 )
 
 # https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MCD12Q1
 MODIS_LC_TYPE3 = Dataset(
     name="MCD12Q1 - MODIS Global Land Cover Type 3",
-    id="MODIS/006/MCD12Q1",
+    id="MODIS/061/MCD12Q1",
     band="LC_Type3",
     labels={
         0: "Water",
@@ -476,7 +476,7 @@ MODIS_LC_TYPE3 = Dataset(
         9: "#f9ffa4",
         10: "#a5a5a5",
     },
-    years=tuple(range(2001, 2021)),
+    years=tuple(range(2001, 2024)),
 )
 
 # https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_Landcover_100m_Proba-V-C3_Global

--- a/sankee/datasets.py
+++ b/sankee/datasets.py
@@ -193,7 +193,7 @@ class Dataset:
 class _LCMS_Dataset(Dataset):
     def get_year(self, year: int) -> ee.Image:
         """Get one year's image from the dataset. LCMS splits up each year into two images: CONUS
-        and SEAK. This merges those into a single image."""
+        and AK. This merges those into a single image."""
         super().get_year(year)
 
         collection = self.collection.filter(ee.Filter.eq("year", year))
@@ -234,34 +234,32 @@ class _CCAP_Dataset(Dataset):
 
 LCMS_LU = _LCMS_Dataset(
     name="LCMS LU - Land Change Monitoring System Land Use",
-    id="USFS/GTAC/LCMS/v2022-8",
+    id="USFS/GTAC/LCMS/v2024-10",
     band="Land_Use",
     labels={
         1: "Agriculture",
         2: "Developed",
         3: "Forest",
-        4: "Non-Forest Wetland",
-        5: "Other",
-        6: "Rangeland or Pasture",
-        7: "No Data",
+        4: "Other",
+        5: "Rangeland or Pasture",
+        6: "No Data",
     },
     palette={
         1: "#efff6b",
         2: "#ff2ff8",
         3: "#1b9d0c",
-        4: "#97ffff",
-        5: "#a1a1a1",
-        6: "#c2b34a",
-        7: "#1B1716",
+        4: "#a1a1a1",
+        5: "#c2b34a",
+        6: "#1B1716",
     },
-    years=tuple(range(1985, 2023)),
+    years=tuple(range(1985, 2025)),
     nodata=7,
 )
 
 # https://developers.google.com/earth-engine/datasets/catalog/USFS_GTAC_LCMS_v2020-5
 LCMS_LC = _LCMS_Dataset(
     name="LCMS LC - Land Change Monitoring System Land Cover",
-    id="USFS/GTAC/LCMS/v2022-8",
+    id="USFS/GTAC/LCMS/v2024-10",
     band="Land_Cover",
     labels={
         1: "Trees",
@@ -297,7 +295,7 @@ LCMS_LC = _LCMS_Dataset(
         14: "#4780f3",
         15: "#1B1716",
     },
-    years=tuple(range(1985, 2023)),
+    years=tuple(range(1985, 2025)),
     nodata=15,
 )
 

--- a/sankee/datasets.py
+++ b/sankee/datasets.py
@@ -638,7 +638,7 @@ CA_FOREST_LC = Dataset(
         220: "#00cc00",
         230: "#cc9900",
     },
-    years=tuple(range(1984, 2020)),
+    years=tuple(range(1984, 2023)),
     nodata=0,
 )
 

--- a/sankee/datasets.py
+++ b/sankee/datasets.py
@@ -253,7 +253,7 @@ LCMS_LU = _LCMS_Dataset(
         6: "#1B1716",
     },
     years=tuple(range(1985, 2025)),
-    nodata=7,
+    nodata=6,
 )
 
 # https://developers.google.com/earth-engine/datasets/catalog/USFS_GTAC_LCMS_v2020-5

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -100,6 +100,16 @@ def test_get_invalid_years():
         sankee.datasets.LCMS_LU.sankify(years=[2017, 2017, 2018], region=None)
 
 
+@pytest.mark.parametrize("dataset", sankee.datasets.datasets, ids=lambda d: d.name)
+def test_nodata_is_valid(dataset):
+    """Check that the nodata value, if present, has corresponding label and palette entries."""
+    if dataset.nodata is not None:
+        assert dataset.nodata in dataset.labels, f"The nodata value {dataset.nodata} has no label."
+        assert (
+            dataset.nodata in dataset.palette
+        ), f"The nodata value {dataset.nodata} has no palette."
+
+
 def test_sankify():
     """Make sure that sankify returns the same results whether called directly or from a Dataset."""
     dataset = sankee.datasets.LCMS_LC

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -17,14 +17,16 @@ def test_get_year_nlcd():
 def test_get_year_LCMS_LC():
     dataset = sankee.datasets.LCMS_LC
     img = dataset.get_year(2016)
-    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2022-8/LCMS_CONUS_v2022-8_2016"
+    # AK and CONUS are mosaiced and properties are copied from the first image
+    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2024-10/LCMS_AK_v2024-10_2016"
     assert img.bandNames().getInfo() == [dataset.band]
 
 
 def test_get_year_LCMS_LU():
     dataset = sankee.datasets.LCMS_LU
     img = dataset.get_year(2016)
-    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2022-8/LCMS_CONUS_v2022-8_2016"
+    # AK and CONUS are mosaiced and properties are copied from the first image
+    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2024-10/LCMS_AK_v2024-10_2016"
     assert img.bandNames().getInfo() == [dataset.band]
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -46,7 +46,7 @@ def test_get_year_MODIS():
 
     for dataset in datasets:
         img = dataset.get_year(2016)
-        assert img.get("system:id").getInfo() == "MODIS/006/MCD12Q1/2016_01_01"
+        assert img.get("system:id").getInfo() == "MODIS/061/MCD12Q1/2016_01_01"
         assert img.bandNames().getInfo() == [dataset.band]
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -33,28 +33,28 @@ def test_plot_parameters(sankey):
     label = [
         "Agriculture",
         "Developed",
-        "Non-Forest Wetland",
+        "Other",
         "Agriculture",
         "Developed",
         "Forest",
-        "Non-Forest Wetland",
+        "Other",
     ]
     link_labels = [
         "<b>100%</b> of <b>Agriculture</b> remained <b>Agriculture</b>",
         "<b>50%</b> of <b>Developed</b> remained <b>Developed</b>",
         "<b>50%</b> of <b>Developed</b> became <b>Forest</b>",
-        "<b>100%</b> of <b>Non-Forest Wetland</b> remained <b>Non-Forest Wetland</b>",
+        "<b>100%</b> of <b>Other</b> remained <b>Other</b>",
     ]
     node_palette = [
         "#efff6b",
         "#ff2ff8",
-        "#97ffff",
+        "#a1a1a1",
         "#efff6b",
         "#ff2ff8",
         "#1b9d0c",
-        "#97ffff",
+        "#a1a1a1",
     ]
-    link_palette = ["#efff6b", "#ff2ff8", "#ff2ff8", "#97ffff"]
+    link_palette = ["#efff6b", "#ff2ff8", "#ff2ff8", "#a1a1a1"]
     source = [0, 1, 1, 2]
     target = [3, 4, 5, 6]
     value = [3, 1, 1, 1]


### PR DESCRIPTION
Updates deprecated assets and includes 2-3 new imagery years for LCMS, CA_FOREST, and MODIS datasets. 

LCMS_LU includes a larger change with the removal of the non-forest wetland class with the 2024-10 version.