### PR TITLE
Allow using unlisted dataset years

### DIFF
--- a/sankee/sampling.py
+++ b/sankee/sampling.py
@@ -10,6 +10,10 @@ class SamplingError(ValueError):
     """Error related to data sampling in Earth Engine."""
 
 
+class ImageUnavailableError(SamplingError):
+    """Error raised when an image is unavailable for sampling."""
+
+
 def handle_sampling_error(e: ee.EEException, band: str, image_list: list[ee.Image]) -> None:
     """Handle Earth Engine errors that occur during sampling by raising more specific errors."""
     msg = None
@@ -23,6 +27,9 @@ def handle_sampling_error(e: ee.EEException, band: str, image_list: list[ee.Imag
             "The sample region is empty. Make sure to pass a valid geometry, feature, or "
             "non-empty collection."
         )
+
+    elif "'object' is required and may not be null" in str(e):
+        raise ImageUnavailableError("One or more of the selected images are unavailable.") from None
 
     if msg:
         raise SamplingError(msg) from None

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,8 +1,11 @@
+import re
+
 import pytest
 from numpy.testing import assert_equal
 from pandas.testing import assert_series_equal
 
 import sankee
+from sankee.sampling import ImageUnavailableError
 
 from .data import TEST_REGION
 
@@ -88,8 +91,10 @@ def test_years(dataset):
 
 
 def test_get_unsupported_year():
-    with pytest.raises(ValueError, match="does not include year"):
-        sankee.datasets.NLCD.get_year(2017)
+    """Test that unsupported years raise when the plot is generated."""
+    expected = re.escape("This dataset does not include the year(s) [1850, 2150]")
+    with pytest.raises(ImageUnavailableError, match=expected):
+        sankee.datasets.NLCD.sankify(years=[1850, 2150], region=TEST_REGION, n=1)
 
 
 def test_get_invalid_years():


### PR DESCRIPTION
Pre-validating the years with the hard-coded dataset year list prevented users accessing newly added assets without a sankee update. Instead, we now try to get the requested years and let GEE fail if they're unavailable. That error is caught and re-raised with the known available years for the given dataset.

This is in lieu of a more direct server-side check for the available years, which would 1) add latency and 2) be complicated with collections that aren't stored by year. I also want to avoid a runtime error when accessing an unlisted year, since that may add unnecessary noise. 