### PR TITLE
Catch missing years for LCMS and CCAP

### DIFF
--- a/sankee/sampling.py
+++ b/sankee/sampling.py
@@ -10,10 +10,6 @@ class SamplingError(ValueError):
     """Error related to data sampling in Earth Engine."""
 
 
-class ImageUnavailableError(SamplingError):
-    """Error raised when an image is unavailable for sampling."""
-
-
 def handle_sampling_error(e: ee.EEException, band: str, image_list: list[ee.Image]) -> None:
     """Handle Earth Engine errors that occur during sampling by raising more specific errors."""
     msg = None
@@ -27,9 +23,6 @@ def handle_sampling_error(e: ee.EEException, band: str, image_list: list[ee.Imag
             "The sample region is empty. Make sure to pass a valid geometry, feature, or "
             "non-empty collection."
         )
-
-    elif "'object' is required and may not be null" in str(e):
-        raise ImageUnavailableError("One or more of the selected images are unavailable.") from None
 
     if msg:
         raise SamplingError(msg) from None

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_equal
 from pandas.testing import assert_series_equal
 
 import sankee
-from sankee.sampling import ImageUnavailableError
 
 from .data import TEST_REGION
 
@@ -20,16 +19,12 @@ def test_get_year_nlcd():
 def test_get_year_LCMS_LC():
     dataset = sankee.datasets.LCMS_LC
     img = dataset.get_year(2016)
-    # AK and CONUS are mosaiced and properties are copied from the first image
-    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2024-10/LCMS_AK_v2024-10_2016"
     assert img.bandNames().getInfo() == [dataset.band]
 
 
 def test_get_year_LCMS_LU():
     dataset = sankee.datasets.LCMS_LU
     img = dataset.get_year(2016)
-    # AK and CONUS are mosaiced and properties are copied from the first image
-    assert img.get("system:id").getInfo() == "USFS/GTAC/LCMS/v2024-10/LCMS_AK_v2024-10_2016"
     assert img.bandNames().getInfo() == [dataset.band]
 
 
@@ -93,7 +88,7 @@ def test_years(dataset):
 def test_get_unsupported_year():
     """Test that unsupported years raise when the plot is generated."""
     expected = re.escape("This dataset does not include the year(s) [1850, 2150]")
-    with pytest.raises(ImageUnavailableError, match=expected):
+    with pytest.raises(ValueError, match=expected):
         sankee.datasets.NLCD.sankify(years=[1850, 2150], region=TEST_REGION, n=1)
 
 


### PR DESCRIPTION
#61 relied on a specific EEException message to validate years, which wasn't being thrown by LCMS and CCAP due to their custom loading function. It's safer to catch *any* exception during `sankify` and validate years then. This could cause a false positive if you encounter a different error while using an unlisted year, but I think that's an unlikely risk that's outweighed by the benefit of reliably catching errors related to missing years.

This also separates the fetching of a given year image from the processing of that image so that Dataset subclasses don't need to duplicate processing, like setting visualization properties. Previously that wasn't being done consistently for LCMS and CCAP. In the process of making those methods more consistent, I removed some properties that were being manually set to speed things up slightly. I don't think those should be required for any reason.