### PR TITLE
Merge duplicated classes during plotting

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -75,3 +75,115 @@ def test_update_layout(sankey):
 
     assert sankey.plot.layout.width == 128
     assert sankey.plot.layout.height == 256
+
+
+def test_duplicate_classes_merged():
+    """Test that classes with identical labels and colors are merged together."""
+    data = pd.DataFrame(
+        {
+            "start": [1, 1, 1, 2, 2, 4],
+            "end": [1, 1, 1, 2, 3, 4],
+        }
+    )
+
+    # The labels and palette combine classes 2, 3, and 4 into a single class "Class B"
+    labels = {
+        1: "Class A",
+        2: "Class B",
+        3: "Class B",
+        4: "Class B",
+    }
+    palette = {
+        1: "#ff0000",
+        2: "#00ff00",
+        3: "#00ff00",
+        4: "#00ff00",
+    }
+
+    plot = sankee.plotting.SankeyPlot(
+        data=data,
+        labels=labels,
+        palette=palette,
+        title="",
+        samples=None,
+        label_type="class",
+        theme="default",
+    )
+
+    # Classes 3 and 4 should be merged into class 2
+    assert plot.data["start"].tolist() == [1, 1, 1, 2, 2, 2]
+    assert plot.data["end"].tolist() == [1, 1, 1, 2, 2, 2]
+    # The duplicated classes should be merged to just two observations
+    assert len(plot.df) == 2
+    # The correct class labels should be used
+    assert plot.df["source_label"].tolist() == ["Class A", "Class B"]
+
+
+def test_duplicate_labels_not_merged():
+    """Test that classes with duplicated labels but distinct colors are preserved."""
+    data = pd.DataFrame(
+        {
+            "start": [1, 1, 1, 2, 2, 4],
+            "end": [1, 1, 1, 2, 3, 4],
+        }
+    )
+
+    # Same labels for classes 2, 3, and 4, but different colors
+    labels = {
+        1: "Class A",
+        2: "Class B",
+        3: "Class B",
+        4: "Class B",
+    }
+    palette = {
+        1: "#ff0000",
+        2: "#00ff00",
+        3: "#008300",
+        4: "#809c80",
+    }
+    plot = sankee.plotting.SankeyPlot(
+        data=data,
+        labels=labels,
+        palette=palette,
+        title="",
+        samples=None,
+        label_type="class",
+        theme="default",
+    )
+    assert plot.data["start"].tolist() == [1, 1, 1, 2, 2, 4]
+    assert plot.data["end"].tolist() == [1, 1, 1, 2, 3, 4]
+
+
+def test_duplicate_colors_not_merged():
+    """Test that classes with duplicated labels but distinct colors are preserved."""
+    data = pd.DataFrame(
+        {
+            "start": [1, 1, 1, 2, 2, 4],
+            "end": [1, 1, 1, 2, 3, 4],
+        }
+    )
+
+    # Same colors for classes 2, 3, and 4, but different labels
+    labels = {
+        1: "Class A",
+        2: "Class B",
+        3: "Class C",
+        4: "Class D",
+    }
+    palette = {
+        1: "#ff0000",
+        2: "#00ff00",
+        3: "#00ff00",
+        4: "#00ff00",
+    }
+    plot = sankee.plotting.SankeyPlot(
+        data=data,
+        labels=labels,
+        palette=palette,
+        title="",
+        samples=None,
+        label_type="class",
+        theme="default",
+    )
+    assert plot.data["start"].tolist() == [1, 1, 1, 2, 2, 4]
+    assert plot.data["end"].tolist() == [1, 1, 1, 2, 3, 4]


### PR DESCRIPTION
Custom and premade datasets can both benefit from aggregating distinct image classes into combined plot classes, e.g. when the classes are too granular. Previously, this would require modifying the Earth Engine image prior to sampling, which can be computationally expensive. 

To avoid that, classes can now be implicitly aggregated by specifying the same label and palette for multiple pixel values. After the values are sampled, they will be aggregated to the first associated value in the labels and palette. For example, imagine you have a collection of images with 4 distinct classes:

```python
img_list = [
    ee.Image.random(0, distribution="uniform").multiply(4).int().rename("label"),
    ee.Image.random(1, distribution="uniform").multiply(4).int().rename("label"),
]

labels = {
    0: "Forest", 
    1: "Shrub", 
    2: "Bare", 
    3: "Crops"
}
palette = {
    0: "#1b9e77", 
    1: "#d95f02", 
    2: "#7570b3", 
    3: "#e7298a"
}

sankee.sankify(
    image_list=img_list, 
    band=["label"], 
    labels=labels,
    palette=palette,
)
```
![image](https://github.com/user-attachments/assets/e91ee268-e138-4055-a08f-8f00b9f3736d)



By specifying duplicate labels and colors for values 1, 2, 3, the resulting plot will combine those samples into a single class.

```python
labels = {
    0: "Forest",
    1: "Nonforest",
    2: "Nonforest",
    3: "Nonforest",
}
palette = {
    0: "#E49635", 
    1: "#397D49", 
    2: "#397D49", 
    3: "#397D49",
}
```
![image](https://github.com/user-attachments/assets/63167cf0-10b4-418d-969e-ff9800f32fb2)
